### PR TITLE
[FIX] Arialabels option not working with functions

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -738,7 +738,10 @@ export default {
     },
     setupDatepicker() {
       if (this.$options.ariaLabels) {
-        this.ariaLabels = copyObject(this.$options.ariaLabels)
+        this.ariaLabels = {
+          ...this.ariaLabels,
+          ...this.$options.ariaLabels,
+        }
       }
       if (this.$options.keyboardShortcuts) {
         this.keyboardShortcuts = copyObject(this.$options.keyboardShortcuts)


### PR DESCRIPTION
Le helper copyObject rendait l'option ariaLabels inutilisable puisqu'elle comporte des fonctions. Cela créait une erreur en lien avec le JSON.parse(JSON.stringify(obj)) du helper.